### PR TITLE
Remove 'container' class from div in carousel to prevent visual glitch during image transition

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,20 +14,20 @@ carousel:
 <div id="main-carousel" class="carousel slide" data-ride="carousel" data-interval="5000">
   <!-- Indicators -->
   <ol class="carousel-indicators">
-	{% for image in page.carousel %}
-    <li data-target="#main-carousel" data-slide-to="{{ forloop.index0 }}"{% if forloop.first %} class="active"{% endif %}></li>
+    {% for image in page.carousel %}
+      <li data-target="#main-carousel" data-slide-to="{{ forloop.index0 }}"{% if forloop.first %} class="active"{% endif %}></li>
     {% endfor %}
   </ol>
 
   <!-- Wrapper for slides -->
   <!-- Lenin help me I hate this goddamn carousel, make sure your images are of fixed height -->
   <div class="carousel-inner">
-	{% for image in page.carousel %}
-    <div class="item{% if forloop.first %} active{% endif %}">
-      <div class="container">
-        <img src="/images/main-carousel/{{ image }}" alt="Pictures of the Boulder DSA">
+    {% for image in page.carousel %}
+      <div class="item{% if forloop.first %} active{% endif %}">
+        <div>
+          <img src="/images/main-carousel/{{ image }}" alt="Pictures of the Boulder DSA">
+        </div>
       </div>
-    </div>
     {% endfor %}
   </div>
 
@@ -53,7 +53,7 @@ Boulder Democratic Socialists of America is an activist organization which seeks
 A call to action:
 
 Are you angry about inequality and injustice in the US? Do you see the problems of racism, sexism, xenophobia and poverty getting worse rather than better? Are you finished with electing representatives that vote with their donors and not their constituents?
- 
+
 It’s time to radically re-define US democracy. Workers have a right to participate in the decisions of their employers. Residents of a community have the right to say whether oil companies can put wells next to their children’s schools. That the wealthiest country in the world can’t adequately feed, shelter, and medically treat all of its citizens is a travesty and embarrassment.
 
 With American life expectancy falling, the wealth gap growing, the public education system under siege, and a President who is the worst example of a racist, sexist, and incredibly incompetent Boss with no virtue but his Extreme Wealth—we are not waiting for someone to save us with promises of Hope and Change. This time, Change will come from below, and it will be overwhelming. Join us and fight. Join us and win.


### PR DESCRIPTION
I'm not 100% certain what was going on to cause this visual glitch, but it appears to be related to how the `container` class was positioning the carousel items in the DOM. As far as I can tell, it adds some left padding to the div surrounding the image which interacts with the `left: 0` property that gets set when transitioning. That's my best guess, at least

Looking at the carousel example in the bootstrap 3.3.7 [docs](https://getbootstrap.com/docs/3.3/javascript/#carousel), it doesn't seem `container` class is required in this case. The carousel and images are still responsive to changes in viewport width without it. I kept the div around, since it keeps the carousel a constant height and width across images. Without it, there's one picture (UAW Spooky Picket Line 2023.jpg) which causes the carousel to resize because it's got different dimensions than the others